### PR TITLE
Darwin Compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ ifdef NBL
 endif
 
 ifdef NORESIZE
-	RESIZE_POLICY = 
+	RESIZE_POLICY =
 endif
 
 ifdef INST
@@ -37,11 +37,11 @@ OPT += $(RESIZE_POLICY) $(BLOCK_LOCKING) $(THRPT_POLICY) $(LATENCY_POLICY) $(PME
 
 CC = clang
 CPP = clang++
-CFLAGS = $(OPT) -Wall -march=native -pthread $(HUGE)
+CFLAGS = $(OPT) -Wall -march=native -pthread -Werror -Wfatal-errors $(HUGE)
+CPPFLAGS = $(OPT) -Wall -march=native -pthread -Werror -Wfatal-errors $(HUGE) -std=c++11
 INCLUDE = -I ./include
 SOURCES = src/iceberg_table.c src/hashutil.c src/partitioned_counter.c src/lock.c
 OBJECTS = $(subst src/,obj/,$(subst .c,.o,$(SOURCES)))
-LIBS = -lssl -lcrypto -ltbb 
 
 ifdef PMEM
 INCLUDE += -I ./pmdk/src/PMDK/src/include
@@ -56,11 +56,11 @@ obj/%.o: src/%.c
 
 obj/main.o: main.cc
 	@ mkdir -p obj
-	$(CPP) $(CFLAGS) $(INCLUDE) -c $< -o $@
+	$(CPP) $(CPPFLAGS) $(INCLUDE) -c $< -o $@
 
 obj/ycsb.o: ycsb.cc
 	@ mkdir -p obj
-	$(CPP) $(CFLAGS) $(INCLUDE) -c $< -o $@
+	$(CPP) $(CPPFLAGS) $(INCLUDE) -c $< -o $@
 
 main: $(OBJECTS) obj/main.o
 	$(CPP) $(CFLAGS) $^ -o $@ $(LIBS)

--- a/main.cc
+++ b/main.cc
@@ -3,7 +3,6 @@
 #include <thread>
 #include <immintrin.h>
 #include <tmmintrin.h>
-#include <openssl/rand.h>
 #include <unistd.h>
 #include <chrono>
 #include <random>
@@ -19,12 +18,12 @@
 using namespace std::chrono;
 
 //vectors of key/value pairs in the table and not in the table
-std::vector<std::pair<uint64_t, uint64_t>> in_table, not_in_table;
+std::vector<std::pair<uint64_t, uint64_t> > in_table, not_in_table;
 
 iceberg_table table;
 
 double elapsed(high_resolution_clock::time_point t1, high_resolution_clock::time_point t2) {
-  return (duration_cast<duration<double>>(t2 - t1)).count();
+  return (duration_cast<duration<double> >(t2 - t1)).count();
 }
 
 void do_inserts(uint8_t id, uint64_t *keys, uint64_t *values, uint64_t start, uint64_t n) {
@@ -107,17 +106,11 @@ void do_removals(uint8_t id, uint64_t *keys, uint64_t start, uint64_t n) {
 }
 
 void safe_rand_bytes(unsigned char *v, size_t n) {
-  while (n > 0) {
-    size_t round_size = n >= INT_MAX ? INT_MAX - 1 : n;
-    RAND_bytes(v, round_size);
-    v += round_size;
-    n -= round_size;
+  size_t round_size = n >= INT_MAX ? INT_MAX - 1 : n;
+  for (uint64_t i = 0; i < round_size; ++i) {
+    v[i] = rand();
   }
 
-  //for (uint64_t i = 0; i < n; ++i) {
-  //v[i] = rand();
-  //}
-     
 }
 
 void do_mixed(uint8_t id, uint64_t *keys, uint64_t *values, uint64_t start, uint64_t n) {
@@ -175,7 +168,7 @@ int main (int argc, char** argv) {
   uint64_t total_alloc = (N * sizeof(uint64_t) * 4)/1024;
 #endif
   if (!is_benchmark) {
-    printf("%ld\n", N * 2 * sizeof(uint64_t));
+    printf("%" PRIu64 "\n", N * 2 * sizeof(uint64_t));
   }
 
   uint64_t *in_keys = (uint64_t *)malloc(N * sizeof(uint64_t));
@@ -250,10 +243,10 @@ int main (int argc, char** argv) {
     printf("Insertions: %f\n", N / elapsed(t1, t2));
 
     printf("Load factor: %f\n", iceberg_load_factor(&table));
-    printf("Number level 1 inserts: %ld\n", lv1_balls(&table));
-    printf("Number level 2 inserts: %ld\n", lv2_balls(&table));
-    printf("Number level 3 inserts: %ld\n", lv3_balls(&table));
-    printf("Total inserts: %ld\n", tot_balls(&table));
+    printf("Number level 1 inserts: %" PRIu64 "\n", lv1_balls(&table));
+    printf("Number level 2 inserts: %" PRIu64 "\n", lv2_balls(&table));
+    printf("Number level 3 inserts: %" PRIu64 "\n", lv3_balls(&table));
+    printf("Total inserts: %" PRIu64 "\n", tot_balls(&table));
   }
 
   uint64_t max_size = 0, sum_sizes = 0;
@@ -264,7 +257,7 @@ int main (int argc, char** argv) {
 
   if (!is_benchmark) {
     printf("Average list size: %f\n", sum_sizes / (double)table.metadata.nblocks);
-    printf("Max list size: %ld\n", max_size);
+    printf("Max list size: %" PRIu64 "\n", max_size);
 
     printf("\nQUERIES\n");
   }

--- a/src/partitioned_counter.c
+++ b/src/partitioned_counter.c
@@ -6,8 +6,6 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <sched.h>
-#include <sys/sysinfo.h>
-#include <linux/unistd.h>
 #include <sys/syscall.h>
 #include <errno.h>
 

--- a/ycsb.cc
+++ b/ycsb.cc
@@ -8,7 +8,6 @@
 #include <stdlib.h>
 #include <atomic>
 #include <thread>
-#include "tbb/tbb.h"
 
 #include "iceberg_table.h"
 
@@ -159,7 +158,7 @@ void ycsb_load_run_randint(int index_type, int wl, int kt, int ap, int num_threa
         txn_count++;
     }
     txn_count--;
-    fprintf(stderr, "Loaded %d txn keys\n", txn_count);
+    fprintf(stderr, "Loaded %" PRIu64 " txn keys\n", txn_count);
 
     std::atomic<int> range_complete, range_incomplete;
     range_complete.store(0);
@@ -253,7 +252,7 @@ void ycsb_load_run_randint(int index_type, int wl, int kt, int ap, int num_threa
                         insert_times.emplace_back(std::chrono::duration_cast<std::chrono::nanoseconds>(t2-t1).count());
 #endif
                     } else if (ops[i] == OP_READ) {
-                        uintptr_t val;
+                        ValueType val;
 #ifdef LATENCY
                         std::chrono::high_resolution_clock::time_point t1 = std::chrono::high_resolution_clock::now();
 #endif
@@ -366,7 +365,6 @@ int main(int argc, char **argv) {
     }
 
     int num_thread = atoi(argv[5]);
-    tbb::task_scheduler_init init(num_thread);
 
     if (kt != STRING_KEY) {
         std::vector<uint64_t> init_keys;


### PR DESCRIPTION
This commit makes several changes that enable IcebergHT to run on Darwin.

1. get_nprocs replaced with #define MAX_PROCS
2. MAP_POPULATE disabled on Darwin/Linux <2.6.22
3. libssl/libcrrypto/libtbb removed
4. -std=c++11 added to CPPFLAGS
5. Unused functions removed
6. Lots of cleanup of warnings