### PR TITLE
Robj/user friendliness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ LIBS = -lssl -lcrypto -ltbb
 
 ifdef PMEM
 INCLUDE += -I ./pmdk/src/PMDK/src/include
-LIBS +=  -L ./pmdk/src/PMDK/src/nondebug -lpmem -lpmemobj
+LIBS += -lpmem -lpmemobj
 endif
 
 all: main ycsb

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,6 @@ OBJECTS = $(subst src/,obj/,$(subst .c,.o,$(SOURCES)))
 LIBS = -lssl -lcrypto
 
 ifdef PMEM
-INCLUDE += -I ./pmdk/src/PMDK/src/include
 LIBS += -lpmem -lpmemobj
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ CFLAGS = $(OPT) -Wall -march=native -pthread $(HUGE)
 INCLUDE = -I ./include
 SOURCES = src/iceberg_table.c src/hashutil.c src/partitioned_counter.c src/lock.c
 OBJECTS = $(subst src/,obj/,$(subst .c,.o,$(SOURCES)))
-LIBS = -lssl -lcrypto -ltbb 
+LIBS = -lssl -lcrypto
 
 ifdef PMEM
 INCLUDE += -I ./pmdk/src/PMDK/src/include

--- a/README.md
+++ b/README.md
@@ -20,12 +20,16 @@ The code uses vector instructions to speed up operatons.
 
 ```bash
  $ make main
- $ ./main 24 4
+ $ ./main -s 24 -t 4
 ```
 
- The argument to main is the log of the number of slots in the hash table and
- the number of threads. For example, to create a hash table with 2^30 slots, the
- argument will be 30.
+The -s flag specifies the log of the number of slots, and the -t flag specifies the number of threads.
+
+To build for PMEM,
+```bash
+ $ PMEM=1 make main
+ $ ./main -p /path/to/pmem -s 24 -t 4
+```
 
 Contributing
 ------------

--- a/include/iceberg_table.h
+++ b/include/iceberg_table.h
@@ -108,8 +108,12 @@ extern "C" {
   uint64_t lv3_balls(iceberg_table * table);
   uint64_t tot_balls(iceberg_table * table);
 
+#ifdef PMEM
+  int iceberg_init(iceberg_table *table, uint64_t log_slots, const char *pmem_dir);
+#else
   int iceberg_init(iceberg_table *table, uint64_t log_slots);
-
+#endif
+  
   double iceberg_load_factor(iceberg_table * table);
 
   bool iceberg_insert(iceberg_table * table, KeyType key, ValueType value, uint8_t thread_id);
@@ -120,7 +124,7 @@ extern "C" {
 
 #ifdef PMEM
   uint64_t iceberg_dismount(iceberg_table *table);
-  int iceberg_mount(iceberg_table *table, uint64_t log_slots, uint64_t resize_cnt);
+  int iceberg_mount(iceberg_table *table, uint64_t log_slots, uint64_t resize_cnt, const char *pmem_dir);
 #endif
 
 #ifdef ENABLE_RESIZE

--- a/ycsb.cc
+++ b/ycsb.cc
@@ -61,10 +61,11 @@ static uint64_t LOAD_SIZE = 64000000;
 static uint64_t RUN_SIZE = 1280000000;
 
 void ycsb_load_run_randint(int index_type, int wl, int kt, int ap, int num_thread,
-        std::vector<uint64_t> &init_keys,
-        std::vector<uint64_t> &keys,
-        std::vector<int> &ranges,
-        std::vector<int> &ops)
+			   std::vector<uint64_t> &init_keys,
+			   std::vector<uint64_t> &keys,
+			   std::vector<int> &ranges,
+			   std::vector<int> &ops,
+			   char *pmem_dir)
 {
     std::string init_file;
     std::string txn_file;
@@ -167,8 +168,11 @@ void ycsb_load_run_randint(int index_type, int wl, int kt, int ap, int num_threa
 
     if (index_type == TYPE_ICEBERG) {
         iceberg_table hashtable;
+#ifdef PMEM
+        iceberg_init(&hashtable, 24, pmem_dir);
+#else
         iceberg_init(&hashtable, 24);
-
+#endif
         thread_data_t *tds = (thread_data_t *) malloc(num_thread * sizeof(thread_data_t));
 
         std::atomic<int> next_thread_id;
@@ -307,13 +311,26 @@ void ycsb_load_run_randint(int index_type, int wl, int kt, int ap, int num_threa
 }
 
 int main(int argc, char **argv) {
-    if (argc != 6) {
-        std::cout << "Usage: ./ycsb [index type] [ycsb workload type] [key distribution] [access pattern] [number of threads]\n";
+#ifdef PMEM
+#define NARGS 7
+#else
+#define NARGS 6
+#endif
+  
+    if (argc != NARGS) {
+#ifdef PMEM
+        std::cout << "Usage: ./ycsb <index type> <ycsb workload type> <key distribution> <access pattern> <number of threads> <pmem directory>\n";
+#else
+        std::cout << "Usage: ./ycsb <index type> <ycsb workload type> <key distribution> <access pattern> <number of threads>\n";
+#endif
         std::cout << "1. index type: iceberg cuckoo dash\n";
         std::cout << "2. ycsb workload type: a, b, c, e\n";
         std::cout << "3. key distribution: randint\n";
         std::cout << "4. access pattern: uniform\n";
         std::cout << "5. number of threads (integer)\n";
+#ifdef PMEM
+	std::cout << "6. directory where pmme files should be stored.\n";
+#endif
         return 1;
     }
 
@@ -366,6 +383,10 @@ int main(int argc, char **argv) {
     }
 
     int num_thread = atoi(argv[5]);
+    char *pmem_dir = NULL;
+#ifdef PMEM
+    pmem_dir = argv[6];
+#endif
     tbb::task_scheduler_init init(num_thread);
 
     if (kt != STRING_KEY) {
@@ -384,7 +405,7 @@ int main(int argc, char **argv) {
         memset(&ranges[0], 0x00, RUN_SIZE * sizeof(int));
         memset(&ops[0], 0x00, RUN_SIZE * sizeof(int));
 
-        ycsb_load_run_randint(index_type, wl, kt, ap, num_thread, init_keys, keys, ranges, ops);
+        ycsb_load_run_randint(index_type, wl, kt, ap, num_thread, init_keys, keys, ranges, ops, pmem_dir);
     }
     /*
     else {

--- a/ycsb.cc
+++ b/ycsb.cc
@@ -8,7 +8,7 @@
 #include <stdlib.h>
 #include <atomic>
 #include <thread>
-#include "tbb/tbb.h"
+//#include "tbb/tbb.h"
 
 #include "iceberg_table.h"
 
@@ -160,7 +160,7 @@ void ycsb_load_run_randint(int index_type, int wl, int kt, int ap, int num_threa
         txn_count++;
     }
     txn_count--;
-    fprintf(stderr, "Loaded %d txn keys\n", txn_count);
+    fprintf(stderr, "Loaded %" PRIu64 " txn keys\n", txn_count);
 
     std::atomic<int> range_complete, range_incomplete;
     range_complete.store(0);
@@ -387,7 +387,7 @@ int main(int argc, char **argv) {
 #ifdef PMEM
     pmem_dir = argv[6];
 #endif
-    tbb::task_scheduler_init init(num_thread);
+    //tbb::task_scheduler_init init(num_thread);
 
     if (kt != STRING_KEY) {
         std::vector<uint64_t> init_keys;


### PR DESCRIPTION
- Remove hard-coded pmem path in `main` and `ycsb`
- Make `main` a little more user-friendly
- Eliminate `tbb` usage in `ycsb`.  I think it was doing nothing anyway.
